### PR TITLE
Fix the sql statements of path and provider_results

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -4,13 +4,13 @@ CREATE TABLE sys_file_processedfile (
 );
 
 CREATE TABLE tx_imageopt_images (
-  path text DEFAULT '',
+  path text NOT NULL,
   optimized tinyint(3) unsigned DEFAULT '0' NOT NULL,
   file_size_before int(11) unsigned DEFAULT '0' NOT NULL,
   file_size_after int(11) unsigned DEFAULT '0' NOT NULL,
   optimization_bytes int(11) unsigned DEFAULT '0' NOT NULL,
   optimization_percentage float NOT NULL DEFAULT '0',
-  provider_results text DEFAULT '',
+  provider_results text NOT NULL,
   provider_winner varchar(255) DEFAULT '' NOT NULL,
 
   uid int(11) NOT NULL auto_increment,


### PR DESCRIPTION
The database analyzer detects fields with defenition "text DEAFULT ''" as schema changes even after executing the database analyzer update query.
"text NOT NULL" matches the TYPO3 standard and the database analyzer shows no updates anymore.