### PR TITLE
#ImageOpt Wrong FAL path to unlink method in ImageManipulationService

### DIFF
--- a/Classes/Service/ImageManipulationService.php
+++ b/Classes/Service/ImageManipulationService.php
@@ -215,7 +215,7 @@ class ImageManipulationService
                         $this->falProcessedFileRepository->update($processedFal);
                         $optimizeSuccess = true;
                         $providerWinner = $optimizationResults['providerOptimizationWinnerKey'];
-                        $theBestOptimizedImage = $processedFal->getIdentifier();
+                        $theBestOptimizedImage = $processedFal->getPublicUrl();
                     }
                     unlink($theBestOptimizedImage);
                 }


### PR DESCRIPTION
Unlink method gets wrong FAL path and it doesn't want to work correctly with Typo6.2