### PR TITLE
[BUGFIX] Prevent PHP fatal error about missing abstract

### DIFF
--- a/Classes/Providers/ImageManipulationProviderBaseRemote.php
+++ b/Classes/Providers/ImageManipulationProviderBaseRemote.php
@@ -29,7 +29,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 /**
  * ImageManipulationProviderBaseRemote
  */
-class ImageManipulationProviderBaseRemote extends ImageManipulationProvider
+abstract class ImageManipulationProviderBaseRemote extends ImageManipulationProvider
 {
     /**
      * Main settings

--- a/Classes/Providers/ImageManipulationProviderBaseShell.php
+++ b/Classes/Providers/ImageManipulationProviderBaseShell.php
@@ -29,7 +29,7 @@ use TYPO3\CMS\Core\Utility\CommandUtility;
 /**
  * Class ImageManipulationProviderBaseShell
  */
-class ImageManipulationProviderBaseShell extends ImageManipulationProvider
+abstract class ImageManipulationProviderBaseShell extends ImageManipulationProvider
 {
     /**
      * Shell executable command. Plz use markers with {executable} and {tempCopy}


### PR DESCRIPTION
In PHP7 you can only extend classes with abstract methods that are
abstract them selfs.